### PR TITLE
新增 Jacob Mei（notoriouslab）的專案（主版面 3 個 + 工程師版面 8 個）

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,11 @@
 * :white_check_mark: [Ultra-Scale Playbook 繁中版](https://ai-twinkle.github.io/ultrascale-playbook-zh-tw/)：超大規模訓練實戰手冊的繁體中文全譯本，線上免費閱讀，附每章互動實驗
 * :white_check_mark: [從零打造 LLM 互動教材](https://ai-twinkle.github.io/llm-from-scratch-course/)：對應《Build a Large Language Model （From Scratch）》各章的原創互動講義，打開網頁即可學
 
+#### Jacob Mei（notoriouslab）（台北） - [GitHub](https://github.com/notoriouslab), [部落格](https://jacobmei.com)
+* :white_check_mark: [TrailPaint 路小繪](https://trailpaint.org/app/)：手繪風路線地圖工具，把登山、旅遊的回憶變成一張插畫風地圖——匯入照片（EXIF 自動抓拍攝地點）或登山 App 的 GPX/KML 路線，3 分鐘就能輸出 IG-ready 圖片或自動導覽的故事地圖；零後端、免註冊、資料全留在瀏覽器，PWA 可裝到手機主畫面，支援中英日三語
+* :white_check_mark: [Doc Cleaner](https://github.com/notoriouslab/doc-cleaner)：文件轉 Markdown 桌面 App（macOS/Windows），把 PDF、Word、Excel、PowerPoint、Apple Keynote/Numbers、EPUB 電子書等 16 種格式拖進視窗，就轉出乾淨的 Markdown——表格完整保留、中文無損，全程在自己電腦上處理不上雲端，免費、零設定
+* :white_check_mark: [Vault Curate](https://community.obsidian.md/plugins/vault-curate)：Obsidian 筆記的語意搜尋外掛，在官方社群外掛市場一鍵安裝——搜「禱告」也能找到寫「靈修」的筆記，中文搜尋特別準；模型在自己電腦上跑，免 API key、免註冊，超過 2,300 人下載使用
+
 ---
 
 ### 關於本清單的整理方式

--- a/pages/README-Programmer-Edition.md
+++ b/pages/README-Programmer-Edition.md
@@ -114,3 +114,13 @@
 #### Maple（Mapleeeeeeeeeee）（台北） - [GitHub](https://github.com/Mapleeeeeeeeeee)
 * :white_check_mark: [cc-session-reader](https://github.com/Mapleeeeeeeeeee/cc-session-reader)：讀取 Claude Code session 記錄並產出精簡摘要的 CLI 工具，純靜態提取不經 LLM，典型可省 80% 以上 token，跨平台附一鍵安裝腳本
 * :white_check_mark: [BilingualSub](https://github.com/Mapleeeeeeeeeee/bilingualsub)：YouTube 雙語字幕產生器，自動語音辨識、LLM 翻譯並輸出 SRT/ASS 雙語字幕，支援硬體加速字幕燒錄
+
+#### Jacob Mei（notoriouslab）（台北） - [GitHub](https://github.com/notoriouslab), [部落格](https://jacobmei.com)
+* :white_check_mark: [doc-cleaner](https://github.com/notoriouslab/doc-cleaner)：日常文件轉 Markdown 的命令列工具，一個指令涵蓋 PDF、Word/Excel/PowerPoint、Apple Keynote/Numbers、EPUB 電子書等 16 種格式，表格完整保留、中文文件友好，全程在本機處理不經雲端，適合建立自己的 AI 知識庫，290+ 星
+* :white_check_mark: [vault-curate](https://github.com/notoriouslab/vault-curate)：Obsidian 語意搜尋外掛，解決「筆記寫『靈修』、搜『禱告』找不到」的痛點——BM25 關鍵字、本機 WebGPU 中文 embedding 模型與模糊標題三路混合檢索，中文搜尋品質勝過一般多語模型，免 API key、已上架官方社群外掛市場
+* :white_check_mark: [bu-ketao 不客套](https://github.com/notoriouslab/bu-ketao)：專為中文設計的 LLM 輸出壓縮規則集——中文 AI 的廢話結構跟英文不同（沒有冠詞可砍），因此歸納出「好的，讓我來幫你分析」「希望這對你有幫助」等 14 類中文特有冗餘，一套規則同時支援 Claude Code、ChatGPT、Cursor、Copilot，實測約 72% token 壓縮且語意零損失
+* :white_check_mark: [browser-mcp-lite](https://github.com/notoriouslab/browser-mcp-lite)：讓 AI 助理操作你「真正的瀏覽器」的 MCP server——沿用 Chrome 已登入的分頁讀網頁、截圖、跑腳本，不像 headless 方案看不到登入狀態；全部程式碼約 500 行、可自行審計，MCP 端點附 token 驗證、擴充功能只要最小權限
+* :white_check_mark: [trad-zh-search](https://github.com/notoriouslab/trad-zh-search)：繁體中文全文檢索的前處理工具，解決主流搜尋引擎靠 jieba（簡中語料訓練）導致繁中分詞品質差的老問題——用中研院 CKIP 分詞加 bigram 索引雙保險，讓「因信稱義」不再被拆成碎片，附可自訂的領域字典，可搭配 Meilisearch、Elasticsearch 等使用
+* :white_check_mark: [issueops-digest](https://github.com/notoriouslab/issueops-digest)：用 GitHub Issue 當操作介面的自動情報收集工具——開 Issue 填關鍵字，GitHub Actions 自動搜尋、AI 評分過濾後回傳勾選清單，在手機上勾選想讀的文章並關閉 Issue，全文就自動抓回來存成 Markdown；免架後台、免月費，fork 即用
+* :white_check_mark: [gmail-statement-fetcher](https://github.com/notoriouslab/gmail-statement-fetcher)：自動從 Gmail 下載銀行對帳單 PDF 的命令列工具，每家銀行的辨識規則寫在 JSON 設定檔裡，新增銀行不用改程式碼；支援 IMAP 與 OAuth 2.0 兩種登入方式，內建去重機制不會重複下載
+* :white_check_mark: [personal-cfo](https://github.com/notoriouslab/personal-cfo)：個人月度財務體檢與退休監控的開源參考實作——銀行帳單進，損益表、資產負債表與退休金投影出，全部用確定性 Python 運算（零 AI 幻覺），內建隨年齡調整股債比的 glide path、偏離軌道才提醒，資料全留本地，fork 後改一個 config.yaml 就能用


### PR DESCRIPTION
你好，自薦投稿 🙋

依投稿指南新增以下條目（開發者：Jacob Mei，台北，GitHub：[notoriouslab](https://github.com/notoriouslab)）。

## 主版面（3 個，打開即用）

- **[TrailPaint 路小繪](https://trailpaint.org/app/)**：手繪風路線地圖工具，匯入照片或 GPX/KML 就能做出插畫風地圖與故事地圖。零後端、免註冊、PWA，中英日三語。
- **[Doc Cleaner](https://github.com/notoriouslab/doc-cleaner)**：文件轉 Markdown 桌面 App（macOS/Windows），16 種格式拖放即轉，中文無損、表格保留、全程本地。
- **[Vault Curate](https://community.obsidian.md/plugins/vault-curate)**：Obsidian 中文語意搜尋外掛，官方社群市場一鍵安裝，2,300+ 下載。

## 工程師版面（8 個）

- **doc-cleaner**：上述 App 的 CLI 版，適合批次處理與 AI agent 整合，290+ 星
- **vault-curate**：上述外掛的技術面——BM25 + 本機 WebGPU 中文 embedding + 模糊比對三路混合檢索
- **bu-ketao 不客套**：專為中文設計的 LLM 輸出壓縮規則集，14 類中文特有冗餘，約 72% token 壓縮
- **browser-mcp-lite**：讓 AI 讀取真實 Chrome（含登入狀態）的極簡 MCP server，約 500 行可審計
- **trad-zh-search**：繁中全文檢索前處理（CKIP 分詞 + bigram），解決 jieba 繁中分詞差的老問題
- **issueops-digest**：GitHub Issue 當操作介面的自動情報收集，搜尋、AI 評分、勾選、自動抓全文
- **gmail-statement-fetcher**：Gmail 銀行對帳單 PDF 自動下載，JSON 設定驅動、新增銀行免改程式
- **personal-cfo**：個人退休財務體檢參考實作，確定性運算、glide path 監控、資料全本地

說明：
- 均為個人 side project、無外部資金，符合收錄標準。
- doc-cleaner 與 vault-curate 比照 Twinkle Hub 的做法雙掛兩版面（主版面寫使用體驗、工程師版寫技術細節）；若您認為外掛類應只留工程師版，請隨意調整或告知，我來改。
- 條目掛在現有的 2026 年 7 月 14 日區塊下，若日期區塊有其他慣例也請隨意調整，謝謝！