### PR TITLE
feat: add Kaohsiung Community Card to Programmer Edition

### DIFF
--- a/pages/README-Programmer-Edition.md
+++ b/pages/README-Programmer-Edition.md
@@ -4,6 +4,11 @@
 
 這裡收錄的是給工程師用的作品——開源函式庫、命令列工具、編輯器外掛與可自架的服務，使用上通常需要寫程式或下指令。給一般人打開即用的網站與 App，請看主版面。
 
+### 2026 年 7 月 18 日新增
+
+#### AndyAWD 與 GDG Kaohsiung 社群團隊（高雄） - [GitHub](https://github.com/gdg-kh)
+* :white_check_mark: [CommunityCardOrg](https://github.com/gdg-kh/CommunityCardOrg)：提供 OpenAPI 規格與 MCP 伺服器的社群名牌卡開源專案，讓 AI 助理可直接查詢高雄在地社群與活動資料
+
 ### 2026 年 7 月 14 日新增
 
 #### Tommy Chen(tommy351) - [GitHub](https://github.com/tommy351)


### PR DESCRIPTION
這是一個將高雄社群名牌卡（CommunityCardOrg）專案加入 awesome-taiwan-project 工程師版面的 Pull Request。該專案提供了 OpenAPI 規格與 MCP 伺服器，讓 AI 助理可以直接查詢高雄在地社群與活動資料。請多指教，謝謝！