### PR TITLE
更新 notoriouslab 條目：新增 HealthWorkbench，並修正 4 個專案的現況資訊

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,10 @@
 * :white_check_mark: [從零打造 LLM 互動教材](https://ai-twinkle.github.io/llm-from-scratch-course/)：對應《Build a Large Language Model （From Scratch）》各章的原創互動講義，打開網頁即可學
 
 #### Jacob Mei（notoriouslab）（台北） - [GitHub](https://github.com/notoriouslab), [部落格](https://jacobmei.com)
-* :white_check_mark: [TrailPaint 路小繪](https://trailpaint.org/app/)：手繪風路線地圖工具，匯入照片或 GPX/KML 路線就能輸出插畫風地圖與故事地圖，零後端、免註冊，支援中英日三語
-* :white_check_mark: [Doc Cleaner](https://github.com/notoriouslab/doc-cleaner)：文件轉 Markdown 桌面 App（macOS/Windows），PDF、Office、EPUB 等 16 種格式拖放即轉，表格保留、中文無損，全程本機處理
-* :white_check_mark: [Vault Curate](https://community.obsidian.md/plugins/vault-curate)：Obsidian 中文語意搜尋外掛，官方社群市場一鍵安裝，模型在本機執行、免 API key，超過 2,300 次下載
+* :white_check_mark: [TrailPaint 路小繪](https://trailpaint.org/app/)：手繪風路線地圖工具，匯入照片或 GPX/KML 路線就能輸出插畫風地圖與故事地圖，手機點地圖即可編輯，零後端、免註冊，支援中英日三語
+* :white_check_mark: [Doc Cleaner](https://github.com/notoriouslab/doc-cleaner)：文件轉 Markdown 桌面 App（macOS/Windows），PDF、Office、EPUB 等 16 種格式拖放即轉，表格保留、中文無損，全程本機處理，macOS 版已通過 Apple 公證、下載後雙擊即開，300+ 星
+* :white_check_mark: [Vault Curate](https://community.obsidian.md/plugins/vault-curate)：Obsidian 中文語意搜尋外掛，官方社群市場一鍵安裝，模型在本機執行、免 API key，桌機建索引、手機與平板讀同一份索引，超過 3,600 次下載
+* :white_check_mark: [HealthWorkbench](https://github.com/notoriouslab/health-workbench)：健康紀錄整理桌面 App（macOS/Windows），把健保健康存摺、Apple 健康與 CPAP 呼吸器的下載檔匯進本機資料庫，突破健康存摺只存三年的限制，可匯出單檔 HTML 或 EPUB 帶去回診，不需帳號、不上雲
 
 #### Ryan Tsai - [GitHub](https://github.com/ryantsai)
 * :white_check_mark: [KKTerm](https://github.com/ryantsai/KKTerm/releases/latest)：跨平台本機優先的遠端管理桌面 App，把終端機、SSH/SFTP、RDP/VNC、檔案與儀表板整合在單一視窗，免費開源且無遙測

--- a/pages/README-Programmer-Edition.md
+++ b/pages/README-Programmer-Edition.md
@@ -121,8 +121,8 @@
 * :white_check_mark: [BilingualSub](https://github.com/Mapleeeeeeeeeee/bilingualsub)：YouTube 雙語字幕產生器，自動語音辨識、LLM 翻譯並輸出 SRT/ASS 雙語字幕，支援硬體加速字幕燒錄
 
 #### Jacob Mei（notoriouslab）（台北） - [GitHub](https://github.com/notoriouslab), [部落格](https://jacobmei.com)
-* :white_check_mark: [doc-cleaner](https://github.com/notoriouslab/doc-cleaner)：文件轉 Markdown 的命令列工具，一個指令涵蓋 16 種格式，表格保留、中文友好、全程本機，適合建自己的 AI 知識庫，290+ 星
-* :white_check_mark: [vault-curate](https://github.com/notoriouslab/vault-curate)：Obsidian 語意搜尋外掛，BM25、本機 WebGPU 中文 embedding 與模糊標題三路混合檢索，中文搜尋品質佳、免 API key
+* :white_check_mark: [doc-cleaner](https://github.com/notoriouslab/doc-cleaner)：文件轉 Markdown 的命令列工具，一個指令涵蓋 16 種格式，表格保留、中文友好、全程本機，適合建自己的 AI 知識庫，300+ 星
+* :white_check_mark: [vault-curate](https://github.com/notoriouslab/vault-curate)：Obsidian 語意搜尋外掛，BM25、本機 WebGPU 中文 embedding 與模糊標題三路混合檢索，中文搜尋品質佳、免 API key，桌機建索引、手機與平板以唯讀方式讀同一份索引，不會有同步衝突
 * :white_check_mark: [bu-ketao 不客套](https://github.com/notoriouslab/bu-ketao)：專為中文設計的 LLM 輸出壓縮規則集，歸納 14 類中文特有冗餘，支援 Claude Code、ChatGPT 等，實測約 72% token 壓縮
 * :white_check_mark: [browser-mcp-lite](https://github.com/notoriouslab/browser-mcp-lite)：讓 AI 助理操作已登入 Chrome 的極簡 MCP server，讀網頁、截圖、跑腳本，全部程式碼約 500 行、可自行審計
 * :white_check_mark: [trad-zh-search](https://github.com/notoriouslab/trad-zh-search)：繁體中文全文檢索前處理工具，以中研院 CKIP 分詞加 bigram 索引改善繁中分詞品質，可搭配 Meilisearch、Elasticsearch


### PR DESCRIPTION
自薦作者更新自己（notoriouslab）在清單裡的條目，一個新作品加上幾筆已上線資訊的修正。

## 主版面（打開即用的網站與 App）

**新增 HealthWorkbench**：健康紀錄整理桌面 App（macOS／Windows），把健保「健康存摺」、Apple 健康與 CPAP 呼吸器的下載檔匯進本機資料庫。健康存摺官方只查得到最近三年，逐次匯入就能無限期累積；可匯出單檔 HTML 或 EPUB 帶去回診，收到的人不必安裝 App。全程本機、不需帳號、不上雲，MIT 授權。

**條目資訊更新**

- Doc Cleaner：macOS 版已改用 Developer ID 簽章並通過 Apple 公證，下載後雙擊即開（過去要右鍵開啟或到系統設定放行），補上 300+ 星
- Vault Curate：新版支援手機與平板（桌機建索引、行動端讀同一份索引），Obsidian 官方市集下載數 2,300+ → 3,600+
- TrailPaint：新版介面手機點地圖就能編輯，補一句在原條目裡

## 工程師版面

- doc-cleaner：290+ 星 → 300+ 星
- vault-curate：補上「桌機建索引、手機與平板唯讀讀取同一份索引」

## 備註

- 星數與下載數為 2026-08-18 實際查得（GitHub API、Obsidian `community-plugin-stats.json`）
- HealthWorkbench 是需要安裝即用的桌面 App，依收錄標準第 3 條放在主版面；若您偏好另開「2026 年 8 月 X 日新增」區塊，或想把新條目挪到別的位置，說一聲我改
- 格式已照投稿指南：狀態符號、中英數之間半形空格、中文全形標點
